### PR TITLE
fix: export image with original colorModel when there are no annotations

### DIFF
--- a/src/components/roi/ROIAnnotations.tsx
+++ b/src/components/roi/ROIAnnotations.tsx
@@ -33,20 +33,22 @@ function ROIAnnotations({
   useEffect(() => {
     if (annotationsRef.current === null) return;
     setSvgRef(annotationsRef);
-  }, [setSvgRef, svgRef]);
+  }, [setSvgRef, svgRef, annotations]);
 
   const transform = usePanZoomTransform();
 
   return (
     <div style={{ width, height }}>
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        style={{ transform, transformOrigin: '0px 0px' }}
-        viewBox={`0 0 ${width} ${height}`}
-        ref={annotationsRef}
-      >
-        {annotations}
-      </svg>
+      {annotations.length > 0 && (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          style={{ transform, transformOrigin: '0px 0px' }}
+          viewBox={`0 0 ${width} ${height}`}
+          ref={annotationsRef}
+        >
+          {annotations}
+        </svg>
+      )}
     </div>
   );
 }

--- a/src/components/tool/ExportTool.tsx
+++ b/src/components/tool/ExportTool.tsx
@@ -72,7 +72,9 @@ function ExportTool() {
         ? (pipelined as Image)
         : pipelined.convertColor(ImageColorModel.RGBA);
     const toSave =
-      annotations === null ? recolored : annotations.copyTo(recolored);
+      annotations === null
+        ? (pipelined as Image)
+        : annotations.copyTo(recolored);
     return toSave;
   }, [pipelined, svgRef]);
 


### PR DESCRIPTION
closes #118 